### PR TITLE
Adding installation of python-devel package

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Installation
 You'll need the pcsc smartcard libraries on your system in order to build the
 smartcard bindings. On Ubuntu:
 
-    sudo apt-get install build-essential swig libpcsclite-dev python-pip
+    sudo apt-get install build-essential swig libpcsclite-dev python-pip python-devel
 
 Then you can install emv from pip:
 


### PR DESCRIPTION
If the python-devel package isn't installed, the pip install fails with a large number of errors, culminating in:
```
smartcard/scard/helpers.c:31:20: fatal error: Python.h: No such file or directory

 #include <Python.h>

                    ^

compilation terminated.
```

Installation of the python-devel package prevents this error.