### PR TITLE
Correctly calculating the CAP value from the ARQC response

### DIFF
--- a/emv/cap.py
+++ b/emv/cap.py
@@ -54,8 +54,7 @@ def get_arqc_req(app_data, value=None, challenge=None):
     return GenerateApplicationCryptogramCommand(GenerateApplicationCryptogramCommand.ARQC,
                                                 cdol1.serialise(data))
 
-
-def get_cap_value(response, ipb):
+def get_cap_value(response, ipb, psn):
     ''' Generate a CAP value from the ARQC response.
         This is the 'proper way' to do it, using the Issuer Proprietary Bitmap from the
         application data response.
@@ -80,6 +79,10 @@ def get_cap_value(response, ipb):
 
     # Get response data into single list, in the same format as IPB
     resp_data = [item for sublist in list(list(response.data.values())[0].values()) for item in sublist]
+
+    # If the PAN Sequence Number is set, then prepend it to the response data
+    if psn is not None:
+        resp_data = psn + resp_data
 
     # Initialise empty string to hold binary result of masking process
     binary_string = ''

--- a/emv/card.py
+++ b/emv/card.py
@@ -125,4 +125,12 @@ class Card(object):
         self.verify_pin(pin)
 
         resp = self.tp.exchange(get_arqc_req(app_data, challenge=challenge, value=value))
-        return get_cap_value(resp, app_data[Tag.IPB])
+        
+        # Set default: don't use PAN Sequence Number
+        psn = None
+
+        # If the third bit of Issuer Authentication Flags is set then use the PAN Sequence Number
+        if (app_data[(0x9F, 0x55)][0] & 0x40):
+            psn = app_data[Tag.PAN_SN]
+
+        return get_cap_value(resp, app_data[Tag.IPB], psn)

--- a/emv/card.py
+++ b/emv/card.py
@@ -125,4 +125,4 @@ class Card(object):
         self.verify_pin(pin)
 
         resp = self.tp.exchange(get_arqc_req(app_data, challenge=challenge, value=value))
-        return get_cap_value(resp)
+        return get_cap_value(resp, app_data[Tag.IPB])


### PR DESCRIPTION
This replaces the algorithm copied from barclays-pinsentry.c with one that uses the IPB (Issuer Proprietary Bitmap) to correctly calculate the response from cards that aren't barclays cards. I've commented it reasonably well so it should be easy enough to understand what's going on even though it uses binary maths and a pretty evil list comprehension.