### PR TITLE
Fixed a bug in read_tag

### DIFF
--- a/emv/protocol/data.py
+++ b/emv/protocol/data.py
@@ -45,10 +45,10 @@ def read_tag(data):
     if is_two_byte(data[i]):
         i += 1
         tag += [data[i]]
-        i += 1
         while len(data) > i and is_continuation(data[i]):
-            tag += [data[i]]
             i += 1
+            tag += [data[i]]
+        i += 1
     else:
         i += 1
     return tag, i

--- a/emv/protocol/structures.py
+++ b/emv/protocol/structures.py
@@ -44,7 +44,7 @@ class TLV(OrderedDict):
             i += tag_len
             if len(data) <= i:
                 log.info("Invalid TLV - read beyond end of buffer at %s: %s", tag, data)
-                return data
+                return tlv
             length = data[i]
             i += 1
             value = data[i : i + length]

--- a/emv/protocol/test/test_structures.py
+++ b/emv/protocol/test/test_structures.py
@@ -31,6 +31,10 @@ class TestTLV(TestCase):
         tlv = TLV.unmarshal(data)
         self.assertEqual(tlv[(0x9F, 0x17)][0], 3)
 
+        data = unformat_bytes("DF DF 39 01 07")
+        tlv = TLV.unmarshal(data)
+        self.assertEqual(tlv[(0xDF, 0xDF, 0x39)][0], 7)
+
     def test_duplicate_tags(self):
         # An ADF entry with a number of records:
         data = unformat_bytes(


### PR DESCRIPTION
1. Fixed a bug in read_tag - is_continuation was called on the the next byte instead of the current byte.

2. When trying to read beyond end of buffer, return the tlv instead of data. This can happen when the data is padded.