### PR TITLE
Fix DEC decoding to pad with zeroes

### DIFF
--- a/emv/util.py
+++ b/emv/util.py
@@ -22,7 +22,7 @@ def from_hex_int(val):
         >>> from_hex_int([0x12, 0x34])
         1234
     """
-    return int("".join(["%x" % i for i in val]))
+    return int("".join(["%02x" % i for i in val]))
 
 
 def from_hex_date(val):


### PR DESCRIPTION
This fixes e.g. rendering of PANs which contain zeros in the middle.

See #17.