### PR TITLE
Add argument for PSE name, fix passing PDOL

### DIFF
--- a/emv/card.py
+++ b/emv/card.py
@@ -27,9 +27,9 @@ class Card(object):
         """Get the master file (MF)."""
         return self.tp.exchange(SelectCommand(file_identifier=[0x3F, 0x00]))
 
-    def get_pse(self):
+    def get_pse(self, pse="1PAY.SYS.DDF01"):
         """Get the Payment System Environment (PSE) file"""
-        return self.tp.exchange(SelectCommand("1PAY.SYS.DDF01"))
+        return self.tp.exchange(SelectCommand(pse))
 
     def list_applications(self):
         """List applications on the card"""
@@ -125,8 +125,8 @@ class Card(object):
 
         return data
 
-    def get_processing_options(self):
-        res = self.tp.exchange(GetProcessingOptions())
+    def get_processing_options(self, pdol=None):
+        res = self.tp.exchange(GetProcessingOptions(pdol))
         if Tag.RMTF1 in res.data:
             # Response template format 1
             return {"AIP": res.data[Tag.RMTF1][:2], "AFL": res.data[Tag.RMTF1][2:]}

--- a/emv/protocol/command.py
+++ b/emv/protocol/command.py
@@ -221,5 +221,6 @@ class GetProcessingOptions(CAPDU):
         if pdol is None:
             self.data = [0x83, 0x00]
         else:
-            self.data = pdol
+            self.data = [0x83, len(pdol)]
+            self.data.extend(pdol)
         self.le = 0x00


### PR DESCRIPTION
Hello,
1. When using EMV for Python with contactless cards it is required to change PSE name to "2PAY.SYS.DDF01" so I propose to add argumet to Card.get_pse() function.
2. When GetProcessingOptions is created with PDOL then length byte is not computated so I propose a fix.

Best Regards,
Przemobe