### PR TITLE
Remove argparse

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
     packages=["emv", "emv.protocol", "emv.command"],
     install_requires=[
         "enum-compat==0.0.3",
-        "argparse==1.4.0",
         "pyscard==2.0.0",
         "pycountry==20.7.3",
         "terminaltables==3.1.0",


### PR DESCRIPTION
`argparse` is a Python[ standard module](https://docs.python.org/3/library/argparse.html) nowadays (starting with Python 3.2). Min. required Python release is 3.4 (see `python_requires=">=3.4",`).