### PR TITLE
Remove enum-compat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
     python_requires=">=3.4",
     packages=["emv", "emv.protocol", "emv.command"],
     install_requires=[
-        "enum-compat==0.0.3",
         "argparse==1.4.0",
         "pyscard==2.0.0",
         "pycountry==20.7.3",


### PR DESCRIPTION
Only required for Python <3.4, constraint is for later Python is present (`python_requires=">=3.4",`).